### PR TITLE
Help: fix du texte noir et blanc sur les boutons et du texte qui dépasse

### DIFF
--- a/src/app/screens/account/settings/Help.tsx
+++ b/src/app/screens/account/settings/Help.tsx
@@ -68,7 +68,7 @@ const Help = () => {
 
         <TabsContent value="faq">
           <View
-            className=" rounded-lg p-2"
+            className="rounded-lg p-2"
             style={{ backgroundColor: theme.card }}
           >
             {faqs.map((faq, index) => (
@@ -77,12 +77,9 @@ const Help = () => {
                   onPress={() => toggleFaq(index)}
                   className="flex-row justify-between items-center py-3"
                 >
-                  <View className="flex-row items-center gap-2 flex-1">
+                  <View className="flex-row items-center gap-2 flex-1 max-w-[80%]">
                     <HelpCircle size={20} color={theme.text} />
-                    <Text
-                      className=" font-medium"
-                      style={{ color: theme.text }}
-                    >
+                    <Text className="font-medium" style={{ color: theme.text }}>
                       {faq.question}
                     </Text>
                   </View>
@@ -122,7 +119,7 @@ const Help = () => {
               >
                 <View className="flex-row items-center gap-3">
                   <SquareArrowOutUpRight size={22} color={theme.text} />
-                  <View className="ml-2.5">
+                  <View className="ml-2.5 max-w-[80%]">
                     <Text style={{ color: theme.text }}>
                       {t("settings.help.joinWhatsApp")}
                     </Text>

--- a/src/components/common/Tabs.tsx
+++ b/src/components/common/Tabs.tsx
@@ -57,10 +57,11 @@ function TabsTrigger({
 
   return (
     <TouchableOpacity
-      className={cn("px-8 py-3 rounded-md flex-1 bg-muted", {
-        "bg-foreground": activeTab === value,
-        className,
-      })}
+      className={cn("px-8 py-3 rounded-md flex-1", className)}
+      style={{
+        backgroundColor:
+          activeTab === value ? theme.foregroundPlaceholder : theme.card,
+      }}
       onPress={() => setActiveTab(value)}
       {...props}
     >


### PR DESCRIPTION
Avant:
![Image](https://github.com/user-attachments/assets/10c78c15-907b-4f19-85e7-b63d2f58e947)

Après:
![Simulator Screenshot - iPhone 16 Pro - 2025-06-06 at 21 01 07](https://github.com/user-attachments/assets/8392c297-5c90-4081-869a-98c7888a9893)

Resolves #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout and text alignment in the Help section by adjusting maximum width constraints and removing extra spaces.
  - Updated tab styling to use theme-based background colors for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->